### PR TITLE
Fix gbda alias

### DIFF
--- a/src/aliases.ps1
+++ b/src/aliases.ps1
@@ -34,7 +34,7 @@ function gba {
 function gbda {
 	$MergedBranchs = $(git branch --merged | Select-String "^(\*|\s*(master|develop|dev)\s*$)" -NotMatch).Line
 	$MergedBranchs | ForEach-Object {
-		git branch -d $_
+		git branch -d $_.Trim()
 	}
 }
 function gbl {


### PR DESCRIPTION
Without the Trim(), this alias didn't work because the content of $_ was '  branch_name' with leading spaces.